### PR TITLE
Fix transform method name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ transform = filelink.transform
 Or by using an external URL via the client:
 
 ```ruby
-transform = client.convert_external('https://someurl.com')
+transform = client.transform_external('https://someurl.com')
 ```
 
 Transformations can be chained together as you please.


### PR DESCRIPTION
The README says `client.convert_external` but it looks like the actual method is `client.transform_external`