### PR TITLE
fix #18: symbolize_keys of options hash when generating security policy

### DIFF
--- a/lib/filestack/models/filestack_security.rb
+++ b/lib/filestack/models/filestack_security.rb
@@ -43,7 +43,7 @@ class FilestackSecurity
   # @param [String]   secret    Your filestack security secret
   # @param [Hash]     options   Hash of options - see constructor
   def generate(secret, options)
-    policy_json = create_policy_string(options)
+    policy_json = create_policy_string(options.symbolize_keys)
     @policy = Base64.urlsafe_encode64(policy_json)
     @signature = OpenSSL::HMAC.hexdigest('sha256', secret, policy)
   end


### PR DESCRIPTION
Corrects an issue where the expiry timestamp of the options hash when creating a security policy is ignored, because the options hash was passed in using string hash keys, and not symbol hash keys. Solved by calling symbolize_keys on the options hash when generating.

Fixes https://github.com/filestack/filestack-ruby/issues/18

I decided against adding or altering any tests, because the current generate test stubs out the hash and signature anyways.