### PR TITLE
parse response_body before reading it

### DIFF
--- a/lib/filestack/mixins/filestack_common.rb
+++ b/lib/filestack/mixins/filestack_common.rb
@@ -2,6 +2,7 @@ require 'filestack/config'
 require 'filestack/utils/utils'
 require 'filestack/utils/multipart_upload_utils'
 require 'mimemagic'
+require 'json'
 
 # Module is mixin for common functionalities that all Filestack
 # objects can call.
@@ -102,7 +103,7 @@ module FilestackCommon
     response = UploadUtils.make_call(url, 'get', parameters: params)
 
     if response.code == 200
-      return response.body
+      return JSON.parse(response.body)
     end
     raise response.body
   end

--- a/lib/filestack/mixins/filestack_common.rb
+++ b/lib/filestack/mixins/filestack_common.rb
@@ -89,7 +89,8 @@ module FilestackCommon
     signature = security.signature
     url = "#{FilestackConfig::CDN_URL}/#{task}/"\
       "security=signature:#{signature},policy:#{policy}/#{handle}"
-    UploadUtils.make_call(url, 'get').body[task]
+    response = UploadUtils.make_call(url, 'get')
+    JSON.parse(response.body)[task]
   end
 
   def send_metadata(handle, security = nil, params)

--- a/lib/filestack/models/filelink.rb
+++ b/lib/filestack/models/filelink.rb
@@ -73,7 +73,7 @@ class FilestackFilelink
 
   # Return metadata for file handle
   #
-  # @return [Typhoeus::Response]
+  # @return [Hash]
   def metadata(params = {})
     send_metadata(@handle, @security, params)
   end

--- a/lib/filestack/models/filestack_av.rb
+++ b/lib/filestack/models/filestack_av.rb
@@ -1,5 +1,6 @@
 require 'filestack/models/filelink'
 require 'filestack/utils/utils'
+require 'json'
 
 # Class for AV objects -- allows to check status
 # and upgrade to filelink once completed
@@ -18,8 +19,9 @@ class AV
   # @return [Filestack::FilestackFilelink]
   def to_filelink
     return 'Video conversion incomplete' unless status == 'completed'
-    response = UploadUtils.make_call(@url, 'get').body
-    handle = response['data']['url'].split('/').last
+    response = UploadUtils.make_call(@url, 'get')
+    response_body = JSON.parse(response.body)
+    handle = response_body['data']['url'].split('/').last
     FilestackFilelink.new(handle, apikey: @apikey, security: @security)
   end
 
@@ -27,6 +29,8 @@ class AV
   #
   # @return [String]
   def status
-    UploadUtils.make_call(@url, 'get').body['status']
+    response = UploadUtils.make_call(@url, 'get')
+    response_body = JSON.parse(response.body)
+    response_body['status']
   end
 end

--- a/lib/filestack/models/filestack_transform.rb
+++ b/lib/filestack/models/filestack_transform.rb
@@ -1,5 +1,6 @@
 require 'filestack/config'
 require 'filestack/models/filestack_av'
+require 'json'
 
 # Class for creating transformation chains and storing them to Filestack
 class Transform
@@ -64,12 +65,13 @@ class Transform
 
   # Add debug parameter to get information on transformation image
   #
-  # @return [Typhoeus::Response]
+  # @return [Hash]
   def debug
     @transform_tasks.push(
       add_transform_task('debug')
     )
-    UploadUtils.make_call(url, 'get').body
+    response = UploadUtils.make_call(url, 'get')
+    JSON.parse(response.body)
   end
 
   # Stores a transformation URL and returns a filelink
@@ -80,7 +82,8 @@ class Transform
       add_transform_task('store', {})
     )
     response = UploadUtils.make_call(url, 'get')
-    handle = response.body['url'].split('/').last
+    response_body = JSON.parse(response.body)
+    handle = response_body['url'].split('/').last
     FilestackFilelink.new(handle, apikey: @apikey, security: @security)
   end
 

--- a/lib/filestack/utils/multipart_upload_utils.rb
+++ b/lib/filestack/utils/multipart_upload_utils.rb
@@ -234,7 +234,7 @@ module MultipartUploadUtils
   # @param [Hash]               options         User-defined options for
   #                                             multipart uploads
   #
-  # @return [Typhoeus::Response]
+  # @return [Hash]
   def multipart_upload(apikey, filepath, security, options, timeout, intelligent: false)
     filename, filesize, mimetype = get_file_info(filepath)
     start_response = multipart_start(
@@ -272,6 +272,6 @@ module MultipartUploadUtils
     rescue
       raise "Upload timed out upon completion. Please try again later"
     end
-    response_complete.body
+    JSON.parse(response_complete.body)
   end
 end

--- a/lib/filestack/utils/utils.rb
+++ b/lib/filestack/utils/utils.rb
@@ -73,7 +73,7 @@ module UploadUtils
   #                                            multipart uploads
   # @param [String]             storage        Storage destination
   #                                            (s3, rackspace, etc)
-  # @return [Typhoeus::Response]
+  # @return [Hash]
   def send_upload(apikey, filepath: nil, external_url: nil, security: nil, options: nil, storage: 'S3')
     data = if filepath
              { fileUpload: File.open(filepath) }
@@ -93,7 +93,8 @@ module UploadUtils
 
     response = make_call(base, 'post', parameters: data)
     if response.code == 200
-      handle = response.body['url'].split('/').last
+      response_body = JSON.parse(response.body)
+      handle = response_body['url'].split('/').last
       return { 'handle' => handle }
     end
     raise response.body
@@ -390,7 +391,7 @@ module IntelligentUtils
     rescue
       raise 'BACKEND_NETWORK'
     end
-    fs_response = fs_response.body
+    fs_response = JSON.parse(fs_response.body)
 
     # PUT to S3
     begin

--- a/spec/filestack/ruby_spec.rb
+++ b/spec/filestack/ruby_spec.rb
@@ -34,7 +34,7 @@ class GeneralResponse
 
   def initialize(body_content, error_number = 200)
     @code = error_number
-    @body = body_content
+    @body = body_content.to_json
   end
 
   def code
@@ -544,14 +544,14 @@ RSpec.describe Filestack::Ruby do
     allow(UploadUtils).to receive(:make_call)
       .and_return(GeneralResponse.new({data: 'data'}))
     metadata = @test_filelink.metadata
-    expect(metadata[:data]).to eq('data')
+    expect(metadata['data']).to eq('data')
   end
 
   it 'gets metadata with security' do
     allow(UploadUtils).to receive(:make_call)
       .and_return(GeneralResponse.new({data: 'data'}))
     metadata = @test_secure_filelink.metadata
-    expect(metadata[:data]).to eq('data')
+    expect(metadata['data']).to eq('data')
   end
 
   ###################

--- a/spec/filestack/ruby_spec.rb
+++ b/spec/filestack/ruby_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe Filestack::Ruby do
       end
 
       def body
-        {'url' => 'https://cdn.filestackcontent.com/somehandle'}
+        {'url' => 'https://cdn.filestackcontent.com/somehandle'}.to_json
       end
     end
     allow(Typhoeus).to receive(:post)
@@ -143,7 +143,7 @@ RSpec.describe Filestack::Ruby do
       end
 
       def body
-        {'url' => 'https://cdn.filestackcontent.com/somehandle'}
+        {'url' => 'https://cdn.filestackcontent.com/somehandle'}.to_json
       end
     end
     allow(Typhoeus).to receive(:post)
@@ -204,7 +204,7 @@ RSpec.describe Filestack::Ruby do
         {
           url: 'someurl',
           headers: 'seomheaders'
-        }
+        }.to_json
       end
     end
     allow(Typhoeus).to receive(:post).and_return(FilestackResponse.new)
@@ -443,7 +443,7 @@ RSpec.describe Filestack::Ruby do
         {
           url: 'someurl',
           headers: 'someheaders'
-        }
+        }.to_json
       end
 
       def code
@@ -472,7 +472,7 @@ RSpec.describe Filestack::Ruby do
         {
           url: 'someurl',
           headers: 'someheaders'
-        }
+        }.to_json
       end
 
       def code
@@ -576,7 +576,7 @@ RSpec.describe Filestack::Ruby do
         { 'status' => 'completed',
           'data' => {
             'url' => 'https://cdn.filestackcontent.com/somehandle'
-          } }
+          } }.to_json
       end
     end
     allow(Typhoeus).to receive(:post).and_return(@response)


### PR DESCRIPTION
Parsing the response body before reading it.

## ref
* [Typhoeus upgrade compatibility issues](https://github.com/filestack/filestack-ruby/issues/28)
* [Typhoeus::Response::Informations#response_body](https://www.rubydoc.info/github/typhoeus/typhoeus/Typhoeus%2FResponse%2FInformations:response_body)
