### PR TITLE
Fixed issue with passed params (mimetype, path, etc.) for external url

### DIFF
--- a/lib/filestack/utils/utils.rb
+++ b/lib/filestack/utils/utils.rb
@@ -58,7 +58,7 @@ module UploadUtils
                 FilestackConfig::HEADERS
               end
     Typhoeus.public_send(
-      action, url, body: parameters, headers: headers
+      action, url, params: parameters, headers: headers
     )
   end
 


### PR DESCRIPTION
https://filestack.atlassian.net/browse/FS-4287