### PR TITLE
Rescues JSON::ParserError and raises body message on upload

### DIFF
--- a/lib/filestack/utils/utils.rb
+++ b/lib/filestack/utils/utils.rb
@@ -63,7 +63,7 @@ module UploadUtils
   end
 
   def build_store_task(options = {})
-    return 'store' if options.empty?
+    return 'store' if options.nil? || options.empty?
     tasks = []
     options.each do |key, value|
       value = case key
@@ -100,7 +100,11 @@ module UploadUtils
     response = Typhoeus.post("#{base}/#{external_url}", headers: FilestackConfig::HEADERS)
 
     if response.code == 200
-      response_body = JSON.parse(response.body)
+      begin
+        response_body = JSON.parse(response.body)
+      rescue
+        raise response.body
+      end
       handle = response_body['url'].split('/').last
       return { 'handle' => handle }
     end

--- a/spec/filestack/ruby_spec.rb
+++ b/spec/filestack/ruby_spec.rb
@@ -606,6 +606,24 @@ RSpec.describe Filestack::Ruby do
     expect(UploadUtils.build_store_task).to eq("store")
   end
 
+  it 'handles non json response' do
+    class UploadResponse
+      def code
+        200
+      end
+
+      def body
+        "docs provider error: conversion was taking too long (idx 0)"
+      end
+
+    end
+    allow(Typhoeus).to receive(:post)
+      .and_return(UploadResponse.new)
+    expect {
+      lamdba UploadUtils.send_upload("fakekey")
+    }.to raise_error(RuntimeError, "docs provider error: conversion was taking too long (idx 0)")
+  end
+
   ###################
   ## TRANFORM TESTS #
   ###################


### PR DESCRIPTION
This is to handle case of when Filestack does not return JSON, but instead returns a plain response.

Example error trace:
```
JSON::ParserError: 435: unexpected token at 'uuid=API-F21xxxxxxxxx] Invalid response when trying to read from http://internal-taskrouters-int-lb-253xxxx.us-east-1.elb.amazonaws.com/output=format:jpg/imVQOBnKTVxxxxx' (Most recent call first)
Hide 4 non-project frames
File /data/xxx/shared/bundled_gems/ruby/2.4.0/gems/json-2.3.1/lib/json/common.rb line 263 in parse
File /data/xxx/shared/bundled_gems/ruby/2.4.0/gems/json-2.3.1/lib/json/common.rb line 263 in parse
File /data/xxx/shared/bundled_gems/ruby/2.4.0/gems/filestack-2.6.7/lib/filestack/utils/utils.rb line 97 in send_upload
File /data/xxxshared/bundled_gems/ruby/2.4.0/gems/filestack-2.6.7/lib/filestack/models/filestack_client.rb line 41 in upload
```