### PR TITLE
Contrib/add deletion to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,19 @@ client = FilestackClient.new('YOUR_API_KEY', security: security)
 ### Using FilestackFilelinks
 FilestackFilelink objects are representation of a file handle. You can download, get raw file content, delete and overwrite file handles directly. Security is required for overwrite and delete methods.
 
+Intialize the filelink using the file handle, your API key, and security if required. The file handle is the string following the last slash `/` in the file URL.
+
+```ruby
+filelink = FilestackFilelink.new(handle, apikey: 'YOUR_API_KEY', security: security_object)
+```
+
+### Deletion
+You can delete a file by simply calling `delete` on the filelink.
+
+```ruby
+filelink.delete
+```
+
 ### Transformations
 Transforms can be initiated one of two ways. The first, by calling ```transform``` on a filelink:
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ client = FilestackClient.new('YOUR_API_KEY', security: security)
 ### Using FilestackFilelinks
 FilestackFilelink objects are representation of a file handle. You can download, get raw file content, delete and overwrite file handles directly. Security is required for overwrite and delete methods.
 
-Intialize the filelink using the file handle, your API key, and security if required. The file handle is the string following the last slash `/` in the file URL.
+Initialize the filelink using the file handle, your API key, and security if required. The file handle is the string following the last slash `/` in the file URL.
 
 ```ruby
 filelink = FilestackFilelink.new(handle, apikey: 'YOUR_API_KEY', security: security_object)


### PR DESCRIPTION
### Improve documentation for deletion and filelink

Currently, new users of the gem need to dig into the source code to understand how to create a filelink object or delete an object. This PR aims to add some clarity.

### Why Was An Issue Not Created?
I thought this was neither a bug nor a feature as stated in the [contributing guide](https://github.com/filestack/filestack-ruby/blob/develop/CONTRIBUTING.md#pull-requests). Not sure if an issue is necessary for a documentation improvement. 
