### PR TITLE
Update mimemagic dependency version

### DIFF
--- a/filestack-ruby.gemspec
+++ b/filestack-ruby.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "typhoeus", "~> 1.1"
   spec.add_dependency "parallel", "~> 1.11", ">= 1.11.2"
-  spec.add_dependency "mimemagic", "~> 0.3.2"
+  spec.add_dependency "mimemagic", "~> 0.3.6"
   spec.add_dependency "progress_bar"
 
   spec.add_development_dependency "bundler", "~> 1.7"


### PR DESCRIPTION
As of last night (this morning?), the maintainer of `mimemagic` has yanked all versions less than `0.3.6` from RubyGems.