### PR TITLE
[fix] Handle nil mimetype of file

### DIFF
--- a/lib/filestack/utils/multipart_upload_utils.rb
+++ b/lib/filestack/utils/multipart_upload_utils.rb
@@ -16,7 +16,7 @@ module MultipartUploadUtils
 
   def get_file_attributes(file, options = {})
     filename = options[:filename] || File.basename(file)
-    mimetype = options[:mimetype] || MiniMime.lookup_by_filename(File.open(file)).content_type || FilestackConfig::DEFAULT_UPLOAD_MIMETYPE
+    mimetype = options[:mimetype] || MiniMime.lookup_by_filename(File.open(file))&.content_type || FilestackConfig::DEFAULT_UPLOAD_MIMETYPE
     filesize = File.size(file)
 
     [filename, filesize, mimetype.to_s]

--- a/lib/filestack/utils/multipart_upload_utils.rb
+++ b/lib/filestack/utils/multipart_upload_utils.rb
@@ -16,7 +16,7 @@ module MultipartUploadUtils
 
   def get_file_attributes(file, options = {})
     filename = options[:filename] || File.basename(file)
-    mimetype = options[:mimetype] || MiniMime.lookup_by_filename(File.open(file)).try(:content_type) || FilestackConfig::DEFAULT_UPLOAD_MIMETYPE
+    mimetype = options[:mimetype] || get_mimetype_from_file(file) || FilestackConfig::DEFAULT_UPLOAD_MIMETYPE
     filesize = File.size(file)
 
     [filename, filesize, mimetype.to_s]
@@ -279,5 +279,13 @@ module MultipartUploadUtils
       raise "Upload timed out upon completion. Please try again later"
     end
     JSON.parse(response_complete.body)
+  end
+
+  private
+
+  def get_mimetype_from_file(file)
+    file_info = MiniMime.lookup_by_filename(File.open(file))
+
+    file_info ? file_info.content_type : nil
   end
 end

--- a/lib/filestack/utils/multipart_upload_utils.rb
+++ b/lib/filestack/utils/multipart_upload_utils.rb
@@ -16,7 +16,7 @@ module MultipartUploadUtils
 
   def get_file_attributes(file, options = {})
     filename = options[:filename] || File.basename(file)
-    mimetype = options[:mimetype] || MiniMime.lookup_by_filename(File.open(file))&.content_type || FilestackConfig::DEFAULT_UPLOAD_MIMETYPE
+    mimetype = options[:mimetype] || MiniMime.lookup_by_filename(File.open(file)).try(:content_type) || FilestackConfig::DEFAULT_UPLOAD_MIMETYPE
     filesize = File.size(file)
 
     [filename, filesize, mimetype.to_s]

--- a/spec/filestack/ruby_spec.rb
+++ b/spec/filestack/ruby_spec.rb
@@ -207,6 +207,15 @@ RSpec.describe Filestack::Ruby do
     expect(mimetype).to eq(@test_mimetype)
   end
 
+  it 'returns default mimetype of Tempfile' do
+    tempfile = Tempfile.new('test.txt')
+
+    _, _, mimetype =
+      MultipartUploadUtils.get_file_attributes(tempfile.path)
+
+    expect(mimetype).to eq('application/octet-stream')
+  end
+
   it 'returns the right IO object attributes' do
     filename, filesize, mimetype =
       MultipartUploadUtils.get_io_attributes(@test_io, @options)


### PR DESCRIPTION
Fix #83

Handle `nil` value which is returned by `MiniMime.lookup_by_filename(File.open(file))`. The method `content_type` is calling every time. Calling `content_type` on `nil` is throwing `Exception`. This fix is handling `content_type` on `nil` value.