### PR TITLE
Replace URI encode to ERB

### DIFF
--- a/lib/filestack/utils/utils.rb
+++ b/lib/filestack/utils/utils.rb
@@ -58,7 +58,7 @@ module UploadUtils
                 FilestackConfig::HEADERS
               end
     Typhoeus.public_send(
-      action, URI.encode(url), params: parameters, headers: headers
+      action, ERB::Util.url_encode(url), params: parameters, headers: headers
     )
   end
 

--- a/lib/filestack/utils/utils.rb
+++ b/lib/filestack/utils/utils.rb
@@ -58,7 +58,7 @@ module UploadUtils
                 FilestackConfig::HEADERS
               end
     Typhoeus.public_send(
-      action, ERB::Util.url_encode(url), params: parameters, headers: headers
+      action, URI::Parser.new.escape(url), params: parameters, headers: headers
     )
   end
 


### PR DESCRIPTION
Closes #89

`URI.encode` has been deprecated since ruby 2.7

New
```ruby
URI::Parser.new.escape '<html>this and that</html>'
=> "%3Chtml%3Ethis%20and%20that%3C/html%3E"
```

Old
```ruby
URI.encode '<html>this and that</html>'
=> "%3Chtml%3Ethis%20and%20that%3C/html%3E"
```

```ruby
"%3Chtml%3Ethis%20and%20that%3C/html%3E" == "%3Chtml%3Ethis%20and%20that%3C/html%3E"
```

Missing tests :(
